### PR TITLE
Fix the failing `tests` workflow for the main branch 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,5 +17,5 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
       - run: pip install -r requirements.txt -r requirements/dev.txt
-      - run: python -m pytest .
+      - run: python -m pytest src
 

--- a/src/web/views_test.py
+++ b/src/web/views_test.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
+from django.test.client import Client as TestClient
 
-def test_index(client):
+def test_index(client: TestClient):
     response = client.get(reverse("web:index"))
     assert response.status_code == 200
-    assert response.content == "Hello, Spokane Python User Group"
+    assert response.content == b"Hello, Spokane Python User Group"


### PR DESCRIPTION
fixes #11

### Description
- Fix the failing `tests` workflow for the main branch
    - The workflow was failing because pytest was targetting the root of the repo instead of the `src` folder
    - The `test_index` was failing because the response content is a bytes object, not a str
- Add a type annotation to the test client to provide better IDE suggestions